### PR TITLE
Disable jQuery dependant vendor script in FastBoot mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var path = require('path');
 var Funnel = require('broccoli-funnel');
 var MergeTrees = require('broccoli-merge-trees');
+var map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'ember-print-this',
@@ -21,6 +22,8 @@ module.exports = {
     var printThisTree = new Funnel(path.dirname(require.resolve('print-this/printThis.js')), {
       files: ['printThis.js'],
     });
+
+    printThisTree = map(printThisTree, content => `if (typeof FastBoot === 'undefined') { ${content} }`);
 
     return vendorTree ? new MergeTrees([vendorTree, printThisTree]): printThisTree;
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-sinon": "^1.0.1",

--- a/testem.js
+++ b/testem.js
@@ -14,6 +14,7 @@ module.exports = {
       args: [
         '--disable-gpu',
         '--headless',
+        '--no-sandbox',
         '--remote-debugging-port=9222',
         '--window-size=1440,900'
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,7 +1111,7 @@ broccoli-config-replace@^1.1.2:
     debug "^2.2.0"
     fs-extra "^0.24.0"
 
-broccoli-debug@^0.6.2, broccoli-debug@^0.6.3:
+broccoli-debug@^0.6.1, broccoli-debug@^0.6.2, broccoli-debug@^0.6.3:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.4.tgz#986eb3d2005e00e3bb91f9d0a10ab137210cd150"
   dependencies:
@@ -1337,6 +1337,25 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     minimatch "^3.0.2"
     resolve "^1.1.6"
     rsvp "^3.0.16"
+    walk-sync "^0.3.0"
+
+broccoli-stew@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
+  dependencies:
+    broccoli-debug "^0.6.1"
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    broccoli-persistent-filter "^1.1.6"
+    broccoli-plugin "^1.3.0"
+    chalk "^1.1.3"
+    debug "^2.4.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^2.0.0"
+    minimatch "^3.0.2"
+    resolve "^1.1.6"
+    rsvp "^3.0.16"
+    symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
 broccoli-uglify-sourcemap@^2.0.0:
@@ -1879,7 +1898,7 @@ debug@2.6.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.9, debug@^2.6.8:
+debug@2.6.9, debug@^2.4.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2988,6 +3007,13 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-extra@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
 
 fs-extra@^4.0.0, fs-extra@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR fixes issue #23 

It is FastBoot's recommended way for disabling vendor scripts when the app is running in FastBoot mode:
[https://github.com/ember-fastboot/ember-cli-fastboot#appimport-in-an-addons-included-hook](https://github.com/ember-fastboot/ember-cli-fastboot#appimport-in-an-addons-included-hook)