### PR TITLE
Moved sinon to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "broccoli-stew": "^1.5.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-sinon": "^1.0.1",
     "print-this": "^1.12.0"
   },
   "devDependencies": {
@@ -44,6 +43,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
+    "ember-sinon": "^1.0.1",
     "ember-source": "~2.16.0",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
Having it under `dependencies` made it pull in a bunch of dependencies related to testing, a few of them deprecated and other ones with vulnerabilities.