### PR TITLE
Fix deprecation (rfcs/text/0750-deprecate-ember-assign.md)

### DIFF
--- a/addon/services/print-this.js
+++ b/addon/services/print-this.js
@@ -1,4 +1,4 @@
-import { assign } from '@ember/polyfills';
+//import { assign } from '@ember/polyfills';
 import { getOwner } from '@ember/application';
 import $ from 'jquery';
 import Service from '@ember/service';
@@ -15,7 +15,7 @@ export default Service.extend({
     const base = environment.rootURL || environment.baseURL;
     const options = base === '/' ? { } : { base };
     
-    return assign(options, userOptions);
+    return Object.assign (options, userOptions);
   },
 
   _selectElement: function(toSelect, jQuery) {


### PR DESCRIPTION
As mentioned in https://github.com/LucasHill/ember-print-this/issues/74

On Ember 5 printthis 2.0 won't work due to using "import { assign } from '@ember/polyfills';" in the printthis service.

https://github.com/emberjs/rfcs/blob/master/text/0750-deprecate-ember-assign.md
https://blog.emberjs.com/ember-5-0-released/

This patch fixes the issue.